### PR TITLE
Add double-slit interference simulation notebook

### DIFF
--- a/double_slit.ipynb
+++ b/double_slit.ipynb
@@ -1,0 +1,82 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Double-slit interference example\n",
+        "\n",
+        "This notebook creates a simple double-slit aperture and computes the far-field (Fraunhofer) diffraction pattern using an FFT. Change parameters like slit width, separation, wavelength, and screen distance to explore the pattern."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import numpy as np\n",
+        "import matplotlib.pyplot as plt\n",
+        "\n",
+        "# Parameters\n",
+        "wavelength = 633e-9          # meters (HeNe laser)\n",
+        "slit_width = 50e-6           # slit width (m)\n",
+        "slit_sep = 200e-6            # center-to-center slit separation (m)\n",
+        "aperture_size = 2.0e-3       # total simulated aperture size (m)\n",
+        "screen_distance = 1.0        # distance to screen (m)\n",
+        "N = 8192                     # number of samples in aperture plane (power of two for FFT)\n",
+        "\n",
+        "# Aperture plane\n",
+        "x = np.linspace(-aperture_size/2, aperture_size/2, N)\n",
+        "dx = x[1] - x[0]\n",
+        "aperture = np.zeros_like(x)\n",
+        "aperture[np.abs(x + slit_sep/2) < slit_width/2] = 1.0\n",
+        "aperture[np.abs(x - slit_sep/2) < slit_width/2] = 1.0\n",
+        "\n",
+        "# Compute far-field using FFT (Fraunhofer approximation)\n",
+        "E = np.fft.fftshift(np.fft.fft(np.fft.ifftshift(aperture))) * dx\n",
+        "I = np.abs(E)**2\n",
+        "I = I / I.max()\n",
+        "\n",
+        "# Map FFT frequencies to screen coordinates\n",
+        "fx = np.fft.fftshift(np.fft.fftfreq(N, d=dx))  # spatial frequency (1/m)\n",
+        "theta = np.arcsin(np.clip(wavelength * fx, -0.9999, 0.9999))  # observation angle\n",
+        "y = screen_distance * np.tan(theta)  # position on screen (m)\n",
+        "\n",
+        "# Sort by y for plotting (fftfreq can wrap order)\n",
+        "order = np.argsort(y)\n",
+        "y_sorted = y[order]\n",
+        "I_sorted = I[order]\n",
+        "\n",
+        "# Plot intensity map and cross-section\n",
+        "plt.figure(figsize=(9, 4))\n",
+        "plt.subplot(1,2,1)\n",
+        "plt.plot(x*1e3, aperture, color='black')\n",
+        "plt.xlabel('Aperture x (mm)')\n",
+        "plt.title('Double-slit aperture')\n",
+        "\n",
+        "plt.subplot(1,2,2)\n",
+        "plt.plot(y_sorted*1e3, I_sorted, color='navy')\n",
+        "plt.xlim(-10, 10)  # show +/- 10 mm on screen (adjust as needed)\n",
+        "plt.xlabel('Screen position y (mm)')\n",
+        "plt.ylabel('Normalized intensity')\n",
+        "plt.title('Fraunhofer diffraction pattern (far field)')\n",
+        "plt.tight_layout()\n",
+        "plt.show()\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.8"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 2
+}


### PR DESCRIPTION
This notebook simulates a double-slit experiment, computing the diffraction pattern using FFT. Users can modify parameters to explore different patterns.